### PR TITLE
`mainLoop` now non-static, uses `bind`

### DIFF
--- a/polyDraw/js/gameLoop.js
+++ b/polyDraw/js/gameLoop.js
@@ -18,9 +18,9 @@ class gameLoop {
     this.level = 1;
   }
 
-  static mainLoop (instance) {
+  mainLoop () {
     //check time of frame start
-    instance.frameStart = performance.now();
+    this.frameStart = performance.now();
     
     // check if mob load needed
 
@@ -29,7 +29,7 @@ class gameLoop {
     // update player position 
 
     // update mob positions
-    instance.updatePosition(instance.mobArray);
+    this.updatePosition(this.mobArray);
 
     // update bullet positions
 
@@ -46,25 +46,27 @@ class gameLoop {
     ctx.clearRect(0, 0, 600, 600);
 
     // draw mobs
-    instance.updateDraw(instance.mobArray);
+    this.updateDraw(this.mobArray);
 
     // draw bullets
 
     // draw player
-    instance.updateDraw(instance.playerArray);
+    this.updateDraw(this.playerArray);
 
     
     // check time elapsed from frame start
-    instance.frameEnd = performance.now();
-    instance.frameDelta = (instance.frameEnd - instance.frameStart);
-    if (instance.frameDelta < instance.frameTime) {
-      instance.frameWait = (instance.frameTime - instance.frameDelta);
-      //console.log(instance.frameDelta);
-      setTimeout(function () { gameLoop.mainLoop(instance); }, instance.frameWait);
+    this.frameEnd = performance.now();
+    this.frameDelta = (this.frameEnd - this.frameStart);
+    if (this.frameDelta < this.frameTime) {
+      this.frameWait = (this.frameTime - this.frameDelta);
+      //console.log(this.frameDelta);
+      // setTimeout(this.mainLoop, this.frameWait);         // This should work, but...
+      setTimeout(this.mainLoop.bind(this), this.frameWait); // ...we need to do this instead, because JS.
     }
     else {
       console.log('crap');
-      setTimeout(function () { gameLoop.mainLoop(instance); }, 1);
+      // setTimeout(this.mainLoop, 1);          // This should work, but...
+      setTimeout(this.mainLoop.bind(this), 1);  // ...we need to do this shit instead, because JS.
     }
   }
 

--- a/polyDraw/js/main.js
+++ b/polyDraw/js/main.js
@@ -26,5 +26,5 @@ gameLoop1.playerArray.push(player1);
 gameLoop1.mobArray.push(mob1);
 gameLoop1.mobArray.push(mob2);
 gameLoop1.mobArray.push(mob3);
-gameLoop.mainLoop(gameLoop1);
+gameLoop1.mainLoop();
 console.log(gameLoop1);


### PR DESCRIPTION
I removed the `instance` parameter from `mainLoop` and made the method non-static, the way it was before. The explicit `instance` parameter was a replacement for the implicit `this` parameter, which was invalid during the call back to `mainLoop` from `setTimeout`. It was invalid because `setTimeout` just kind of sucks that way.

Now `this` is valid in each iteration, because the function we pass to `setTimeout` is `this.mainLoop.bind(this)`, rather than just `this.mainLoop`.

[`bind` is a method you can call on any function object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind). It returns a slightly *different* function, and within the body of that function the value of `this` is equal to whatever argument we pass to `bind`. Importantly, it has that value even if `setTimeout` tries to invalidate it.

So, the value of the expression `this.mainLoop.bind(this)` is a function that does everything `this.mainLoop` does, with the added assurance that when it is called by `setTimeout`, `this` has the same value that `this` has at the time we call `bind`—namely, the same instance of `gameLoop`, called `gameLoop1` in main.js.

Why do we need to make extra special sure that the callback we pass to `setTimeout` is immune to its unintuitive `this`-fucking powers? The world may never know...