### PR TITLE
Set some methods of `gameLoop` to "bound" versions of themselves

### DIFF
--- a/polyDraw/js/gameLoop.js
+++ b/polyDraw/js/gameLoop.js
@@ -26,6 +26,10 @@ class gameLoop {
     this.leftPressed = false;
     this.rightPressed = false;
     this.rightPressed = false;
+
+    this.mainLoop = this.mainLoop.bind(this);
+    this.keyDown = this.keyDown.bind(this);
+    this.keyUp = this.keyUp.bind(this);
   }
 
   mainLoop () {
@@ -73,13 +77,11 @@ class gameLoop {
     if (this.frameDelta < this.frameTime) {
       this.frameWait = (this.frameTime - this.frameDelta);
       //console.log(this.frameDelta);
-      // setTimeout(this.mainLoop, this.frameWait);         // This should work, but...
-      setTimeout(this.mainLoop.bind(this), this.frameWait); // ...we need to do this instead, because JS.
+      setTimeout(this.mainLoop, this.frameWait);
     }
     else {
       console.log('crap');
-      // setTimeout(this.mainLoop, 1);          // This should work, but...
-      setTimeout(this.mainLoop.bind(this), 1);  // ...we need to do this shit instead, because JS.
+      setTimeout(this.mainLoop, 1);
     }
   }
 


### PR DESCRIPTION
Here's a little trick I found: call `bind` on your class's methods once and for all inside the class's constructor, and replace them with the resulting "bound" methods.

Then you can pass the methods themselves to `setTimeout` or `addEventListener` instead of calling `bind` on them and passing the result. That's what you were trying to do originally, before you found out that it doesn't work by default.

More here (in the context of deriving new classes from ones in the React library):
https://stackoverflow.com/questions/36309636/why-binding-is-needed-in-es6-react-classes